### PR TITLE
Added setting payment_processor_account_id based on currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ curl -v \
     :login: "your-username"
     :password: "your-password"
     :secure_page_url: "litle-secure-page-url"
-    :paypage_id: "your-paypage-id-EUR"' \
+    :paypage_id: "your-paypage-id-EUR" 
+:multicurrency:
+  :USD: "USD"
+  :EUR: "EUR"' \
      http://127.0.0.1:8080/1.0/kb/tenants/uploadPluginConfig/killbill-litle
 ```
+
+`multicurrency` setting provides the mapping between trasaction currency to `account_Id`.  The default currency is the first key in the `multicurrency` config, in the example above, it is `"USD"`.  If `multicurrency` is not present, the default `account_id` will be the first `account_id` in `litle` dictionary.
 
 To go to production, create a `litle.yml` configuration file under `/var/tmp/bundles/plugins/ruby/killbill-litle/x.y.z/` containing the following:
 

--- a/lib/litle/api.rb
+++ b/lib/litle/api.rb
@@ -189,8 +189,10 @@ module Killbill #:nodoc:
       def set_payment_processor_account_id(currency, kb_tenant_id=nil)
         config = ::Killbill::Plugin::ActiveMerchant.config(kb_tenant_id)
         options = {}
-        if config[:multicurrency]
-          options = {:payment_processor_account_id => currency}
+        currency_account_id_map = config[:multicurrency]
+        if currency_account_id_map && currency_account_id_map.is_a?(Hash)
+          currency_account_id_map[:default] = currency_account_id_map.values[0]
+          options = {:payment_processor_account_id => currency_account_id_map[currency.to_sym]}
         end
         options
       end

--- a/lib/litle/api.rb
+++ b/lib/litle/api.rb
@@ -191,7 +191,7 @@ module Killbill #:nodoc:
         options = {}
         currency_account_id_map = config[:multicurrency]
         if currency_account_id_map && currency_account_id_map.is_a?(Hash)
-          currency_account_id_map[:default] = currency_account_id_map.values[0]
+          currency_account_id_map.default = currency_account_id_map.values[0]
           options = {:payment_processor_account_id => currency_account_id_map[currency.to_sym]}
         end
         options

--- a/lib/litle/api.rb
+++ b/lib/litle/api.rb
@@ -28,7 +28,7 @@ module Killbill #:nodoc:
 
       def authorize_payment(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
         # Pass extra parameters for the gateway here
-        options = {}
+        options = set_payment_processor_account_id(currency, context.tenant_id) 
 
         paypage_registration_id = find_value_from_properties(properties, 'paypageRegistrationId')
         options[:paypage_registration_id] = paypage_registration_id unless paypage_registration_id.blank?
@@ -39,7 +39,7 @@ module Killbill #:nodoc:
 
       def capture_payment(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
         # Pass extra parameters for the gateway here
-        options = {}
+        options = set_payment_processor_account_id(currency, context.tenant_id) 
 
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
@@ -47,7 +47,7 @@ module Killbill #:nodoc:
 
       def purchase_payment(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
         # Pass extra parameters for the gateway here
-        options = {}
+        options = set_payment_processor_account_id(currency, context.tenant_id) 
 
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
@@ -55,7 +55,7 @@ module Killbill #:nodoc:
 
       def void_payment(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, properties, context)
         # Pass extra parameters for the gateway here
-        options = {}
+        options = set_payment_processor_account_id(currency, context.tenant_id) 
 
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, properties, context)
@@ -63,7 +63,7 @@ module Killbill #:nodoc:
 
       def credit_payment(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
         # Pass extra parameters for the gateway here
-        options = {}
+        options = set_payment_processor_account_id(currency, context.tenant_id) 
 
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
@@ -71,7 +71,7 @@ module Killbill #:nodoc:
 
       def refund_payment(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
         # Pass extra parameters for the gateway here
-        options = {}
+        options = set_payment_processor_account_id(currency, context.tenant_id) 
 
         properties = merge_properties(properties, options)
         super(kb_account_id, kb_payment_id, kb_payment_transaction_id, kb_payment_method_id, amount, currency, properties, context)
@@ -184,6 +184,15 @@ module Killbill #:nodoc:
           # Set the response body
           # gw_notification.entity =
         end
+      end
+
+      def set_payment_processor_account_id(currency, kb_tenant_id=nil)
+        config = ::Killbill::Plugin::ActiveMerchant.config(kb_tenant_id)
+        options = {}
+        if config[:multicurrency]
+          options = {:payment_processor_account_id => currency}
+        end
+        options
       end
     end
   end

--- a/litle.yml
+++ b/litle.yml
@@ -15,6 +15,9 @@
     :secure_page_url: "https://request-prelive.np-securepaypage-litle.com"
     :paypage_id: "litle-paypage-id-EUR"
     :test: "<%= ENV['LITLE_TEST'] || true %>"
+:multicurrency:
+  :USD: "USD"
+  :EUR: "EUR"
 
 :database:
 # SQLite (development)


### PR DESCRIPTION
Added new function that will set payment_processor_account_id based on the currency of the transaction.  This is controlled by a new plugin config `:multicurrency`.